### PR TITLE
[Refactor] importing bind from 'bind-decorator' before using it

### DIFF
--- a/src/Keyboard.tsx
+++ b/src/Keyboard.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import bind from 'bind-decorator';
 import Dialog from 'material-ui/Dialog';
 import TextField from 'material-ui/TextField';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';

--- a/src/KeyboardKey.tsx
+++ b/src/KeyboardKey.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import bind from 'bind-decorator';
 import FlatButton from 'material-ui/FlatButton';
 import Backspace from 'material-ui/svg-icons/content/backspace';
 import Enter from 'material-ui/svg-icons/hardware/keyboard-return';


### PR DESCRIPTION
Importing `bind from 'bind-decorator'` before using it.
