### PR TITLE
Fixes #16 [TypeScript] React.createElement is not callable with KeyboardKey

### DIFF
--- a/src/KeyboardKey.tsx
+++ b/src/KeyboardKey.tsx
@@ -20,7 +20,7 @@ export interface KeyboardKeyProps {
 }
 
 export class KeyboardKey extends React.Component<KeyboardKeyProps, void> {
-    public static propTypes: Object = {
+    public static propTypes: React.ValidationMap<KeyboardKeyProps> = {
         keyboardKey: React.PropTypes.string.isRequired,
         onKeyPress: React.PropTypes.func.isRequired,
         keyboardKeyWidth: React.PropTypes.number.isRequired,


### PR DESCRIPTION
Fixing #16 [TypeScript] `React.createElement` is not callable with `KeyboardKey`
