### PR TITLE
Fixes #5 [Refactor] Instead of deleting ['minWidth', 'width', 'maxWidth'] set them to '100%' and stop using fullwidth prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ Props marked with \* are required.
 
 - `value`\* of type `string`
 - `onKeyDown`\* of type `function(event: React.KeyboardEvent)`
-- `fullWidth` of type `bool`
 - `readOnly`\* of type `bool`
 
 Props marked with \* must be passed down to the native `input` element.

--- a/src/Keyboard.tsx
+++ b/src/Keyboard.tsx
@@ -56,7 +56,6 @@ export interface TextFieldRequiredProps {
     readOnly: boolean;
     value: string; 
     onKeyDown: React.KeyboardEventHandler;
-    fullWidth: boolean;
 }
 
 export interface TextFieldAccessedProps extends TextFieldRequiredProps {
@@ -341,9 +340,7 @@ export class Keyboard extends React.Component<KeyboardProps, KeyboardState> {
         let keyboardFieldProps: any = ObjectAssign({}, textFieldElement.props);
         let keyboardFieldStyle: any = ObjectAssign({}, styles);
         ['minWidth', 'width', 'maxWidth'].forEach((prop: string): void => {
-            if(keyboardFieldStyle.hasOwnProperty(prop)) {
-                delete keyboardFieldStyle[prop];
-            }
+            keyboardFieldStyle[prop] = '100%';
         });
         ['onChange', 'onFocus', 'onBlur', 'onKey', 'onKeyUp', 'onKeyDown', 'onKeyPress'].forEach((prop: string): void => {
             if(keyboardFieldProps.hasOwnProperty(prop)) {
@@ -353,7 +350,6 @@ export class Keyboard extends React.Component<KeyboardProps, KeyboardState> {
         ObjectAssign(keyboardFieldProps, {
             readOnly: true,
             value: value, 
-            fullWidth: true,
             style: keyboardFieldStyle,
             ref: _refKeyboardField
         });


### PR DESCRIPTION
Fixing #5 [Refactor] Instead of deleting `['minWidth', 'width', 'maxWidth']` set them to `'100%'` and stop using `fullwidth` `prop`.
